### PR TITLE
Fix the Disc Camera recipe.

### DIFF
--- a/src/main/resources/data/camera_port/recipe/disc_camera.json
+++ b/src/main/resources/data/camera_port/recipe/disc_camera.json
@@ -10,7 +10,7 @@
       "item": "camera_port:camera"
     },
     "x": {
-      "tag": "minecraft:music_discs"
+      "tag": "c:music_discs"
     }
   },
   "result": {


### PR DESCRIPTION
Fix the namespace for the "music_discs" tag, fixing the Disc Camera recipe.